### PR TITLE
Include libatomic1 in Dockerfile apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt update \
     && echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/pgdg.gpg \
     && apt-get update \
-    && apt-get install -y supervisor git unzip postgresql-client-17 default-mysql-client zsh procps \
+    && apt-get install -y supervisor git unzip postgresql-client-17 default-mysql-client zsh procps libatomic1 \
     && echo 'source /etc/profile.d/.env' >> /etc/bash.bashrc \
     && curl -fsSL https://get.pnpm.io/install.sh | env PNPM_HOME="${PNPM_HOME}" bash - \
     && export PATH="${PNPM_HOME}:${PATH}" \


### PR DESCRIPTION
### Motivation
- Add `libatomic1` to the base image package list to satisfy runtime library requirements and avoid missing-library errors in the container.

### Description
- Inserted `libatomic1` into the `apt-get install -y` package list in the `Dockerfile` while leaving the rest of the build steps unchanged.

### Testing
- Executed an automated `docker build -t frankenphp:local .` which completed successfully and reported no package installation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e5d2267fc83248fb3e15535cd5115)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a required system dependency to improve application compatibility and runtime stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->